### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,10 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   def create
     @item = Item.new(item_params)
     if @item.save

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
-     @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,8 +14,7 @@ class Item < ApplicationRecord
     validates :scheduled_delivery_id
     validates :prefecture_id
   end
-    
-  
+
   belongs_to :user
   # has_one :purchase
   has_one_attached :image

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
        <% @items.each do |item| %>
       
       <li class='list'>
-        <%= link_to "#"  do %>
+        <%= link_to item_path(item.id), method: :get do %>
         <div class='item-img-content'>
           <%= image_tag item.image , class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.info %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.sales_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in?   %>
     <% if current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
@@ -35,9 +34,6 @@
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
     <% end %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.info %></span>
@@ -105,9 +101,6 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a> 
 </div>
-
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,22 +16,25 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.price %> 
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee_status.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in?   %>
+    <% if current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
+    <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -15,4 +15,3 @@ FactoryBot.define do
     end
   end
 end
-

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Item, type: :model do
   end
 
   describe '商品出品機能' do
-
     context '商品出品がうまくいくとき' do
       it 'imageがあれば登録できること' do
         expect(@item).to be_valid
@@ -23,7 +22,7 @@ RSpec.describe Item, type: :model do
       end
 
       it 'category_idで---以外を選択すると登録できること' do
-         @item.category_id = 2
+        @item.category_id = 2
         expect(@item).to be_valid
       end
 
@@ -53,7 +52,7 @@ RSpec.describe Item, type: :model do
       end
 
       it 'priceが半角数字であれば登録できること' do
-        @item.price = 30000
+        @item.price = 30_000
         expect(@item).to be_valid
       end
     end
@@ -74,34 +73,31 @@ RSpec.describe Item, type: :model do
       it 'category_idで---を選択すると登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
 
       it 'prefecture_idで---を選択すると登録できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
       end
 
       it 'shipping_fee_status_idで---を選択すると登録できない' do
         @item.shipping_fee_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee status must be other than 1")
-                                                      
+        expect(@item.errors.full_messages).to include('Shipping fee status must be other than 1')
       end
 
       it 'sales_status_idで---を選択すると登録できない' do
         @item.sales_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Sales status must be other than 1")
-                                                      
+        expect(@item.errors.full_messages).to include('Sales status must be other than 1')
       end
 
       it 'scheduled_delivery_idで---を選択すると登録できない' do
         @item.scheduled_delivery_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Scheduled delivery must be other than 1")
-                                                      
+        expect(@item.errors.full_messages).to include('Scheduled delivery must be other than 1')
       end
 
       it 'priceが空だと登録できない' do
@@ -117,7 +113,7 @@ RSpec.describe Item, type: :model do
       end
 
       it 'priceが9999999より大きいと登録できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price is invalid')
       end
@@ -129,15 +125,15 @@ RSpec.describe Item, type: :model do
       end
 
       it 'priceが英数字混合だと登録できないこと' do
-       @item.price = '123abc'
+        @item.price = '123abc'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is invalid") 
+        expect(@item.errors.full_messages).to include('Price is invalid')
       end
 
       it 'priceが半角英字では登録できないこと' do
         @item.price = 'abcdef'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is invalid") 
+        expect(@item.errors.full_messages).to include('Price is invalid')
       end
 
       it 'imageが空だと登録できない' do


### PR DESCRIPTION
# What
商品詳細表示機能
# Why
出品した商品の詳細を表示できるようにするため
https://gyazo.com/79a4b88c4038faae10f951309735417a
https://gyazo.com/5707463e2bd13ab4923ac4fa86ae55c3
https://gyazo.com/a7bcd87c78a431ae84badb82b668c34a
商品購入機能の実装をまだ実装していません